### PR TITLE
use license property instead of licenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,7 @@
     "name": "Benjamin Otto",
     "email": "benjamin.otto@mercateo.com"
   },
-  "licenses": [
-    {
-      "type": "Apache-2.0",
-      "url": "https://github.com/Mercateo/dwatch/blob/master/LICENSE.md"
-    }
-  ],
+  "license": "Apache-2.0",
   "homepage": "https://github.com/Mercateo/dwatch",
   "scripts": {
     "postinstall": "install-app-deps && typings i",


### PR DESCRIPTION
According to https://docs.npmjs.com/files/package.json#license the `licenses` array in the `package.json` is deprecated as well as using an object with `type` and `url` properties. The only valid format is the `license` property with a "[SPDX license expression syntax version 2.0 string](https://npmjs.com/package/spdx)".